### PR TITLE
Refactor: error for absent environment variables

### DIFF
--- a/www/src/lib/redis.ts
+++ b/www/src/lib/redis.ts
@@ -1,6 +1,13 @@
 import { Redis } from '@upstash/redis'
 
+const token = process.env.UPSTASH_REDIS_REST_TOKEN
+const url = process.env.UPSTASH_REDIS_REST_URL
+
+if(!url || !token) {
+  throw new Error('missing the following environment variables: \nUPSTASH_REDIS_REST_URL=\nUPSTASH_REDIS_REST_TOKEN')
+}
+
 export const redis = new Redis({
-  url: process.env.UPSTASH_REDIS_REST_URL!,
-  token: process.env.UPSTASH_REDIS_REST_TOKEN!,
+  url,
+  token
 })


### PR DESCRIPTION
When i first ran the repo i had a hard time running the project in development, after a few minutes of looking at the error i found that i was missing the redis keys to be able to run the repo. this PR includes a check for the redis keys and gives an easier to understand error when these keys are absent.