### PR TITLE
Support for other languages then Typescript in the example code snippet

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-scroll-area": "^1.0.5",
+    "@radix-ui/react-select": "^2.0.0",
     "@radix-ui/react-slot": "^1.0.2",
     "@tanstack/react-query": "^5.29.2",
     "@upstash/redis": "^1.30.0",

--- a/www/src/app/page.tsx
+++ b/www/src/app/page.tsx
@@ -242,9 +242,7 @@ export default async function Home() {
             id='api'
             className='w-full flex flex-col items-center mt-12 px-4'>
             <p className='font-bold text-xl my-4'>Make an API request</p>
-            <div className='relative max-w-2xl w-full text-left p-5 bg-[#1e1e1e] rounded-xl shadow'>
-              <CodeSection />
-            </div>
+            <CodeSection />
           </div>
         </div>
       </section>

--- a/www/src/components/Code.tsx
+++ b/www/src/components/Code.tsx
@@ -1,11 +1,11 @@
 'use client'
 
 import { cn } from '@/lib/utils'
-import { Highlight, themes } from 'prism-react-renderer'
+import { Highlight, Language, themes } from 'prism-react-renderer'
 
-const Code = ({ code }: { code: string }) => {
+const Code = ({ code, language }: { code: string, language: Language }) => {
   return (
-    <Highlight theme={themes.vsDark} code={code} language='tsx'>
+    <Highlight theme={themes.vsDark} code={code} language={language}>
       {({ className, style, tokens, getLineProps, getTokenProps }) => (
         <pre style={style} className={cn(className, 'w-fit')}>
           {tokens.map((line, i) => {

--- a/www/src/components/CodeSection.tsx
+++ b/www/src/components/CodeSection.tsx
@@ -1,22 +1,106 @@
-"use client"
+"use client";
 
-import Code from './Code'
-import { ScrollArea, ScrollBar } from './ui/scroll-area'
+import { Language } from "prism-react-renderer";
+import Code from "./Code";
+import { ScrollArea, ScrollBar } from "./ui/scroll-area";
+import { useState } from "react";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+const API_URL = 'https://vector.profanity.dev';
 
-const codeBlock = `const res = await fetch('https://vector.profanity.dev', {
-  method: 'POST',
-  headers: { 'Content-Type': 'application/json' },
-  body: JSON.stringify({ message }),
-})`
+const codeBlocks: Record<Language, string> = {
+  tsx: `const res = await fetch('${API_URL}', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ message }),
+  })`,
+  python: `import requests
 
-const CodeSection = () => {
-  return (
-    <ScrollArea className='relative'>
-      <Code code={codeBlock} />
+res = requests.post(
+  '${API_URL}', 
+  json={'message': message}
+)`,
+  go: `import (
+  "bytes"
+  "encoding/json"
+  "net/http"
+  "log"
+)
 
-      <ScrollBar orientation="horizontal" />
-    </ScrollArea>
-  )
+reqBody, err := json.Marshal(map[string]string{"message": message})
+if err != nil {
+  log.Fatal(err)
 }
 
-export default CodeSection
+res, err := http.Post(
+  '${API_URL}', 
+  "application/json", 
+  bytes.NewBuffer(reqBody)
+)
+
+if err != nil {
+  log.Fatal(err)
+}`,
+  java: `import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpRequest.BodyPublishers;
+
+HttpClient client = HttpClient.newHttpClient();
+HttpRequest request = HttpRequest.newBuilder()
+  .uri(URI.create('${API_URL}'))
+  .header("Content-Type", "application/json")
+  .POST(BodyPublishers.ofString("{\"message\": \"" + message + "\"}"))
+  .build();
+try {
+  HttpResponse<String> response = client.send(
+    request, 
+    HttpResponse.BodyHandlers.ofString()
+  );
+} catch (Exception e) {
+  e.printStackTrace();
+}`,  
+};
+
+const CodeSection = () => {
+  const [language, setLanguage] = useState<Language>("tsx");
+  return (
+    <>
+      <div className=" relative max-w-2xl w-full">
+        <Select defaultValue="tsx" onValueChange={setLanguage}>
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              <SelectItem value="tsx">TypeScript</SelectItem>
+              <SelectItem value="python">Python</SelectItem>
+              <SelectItem value="go">Go</SelectItem>
+              <SelectItem value="java">Java</SelectItem>
+            </SelectGroup>
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="relative max-w-2xl w-full text-left p-5 bg-[#1e1e1e] rounded-xl shadow mt-2">
+        <ScrollArea className="relative">
+          {codeBlocks[language] !== undefined ? (	
+          <Code language="tsx" code={codeBlocks[language]} />
+          ) : (
+          <div className="text-white">No code available for this language</div>
+          )}
+          <ScrollBar orientation="horizontal" />
+        </ScrollArea>
+      </div>
+    </>
+  );
+};
+
+export default CodeSection;

--- a/www/src/components/ui/select.tsx
+++ b/www/src/components/ui/select.tsx
@@ -1,0 +1,164 @@
+"use client"
+
+import * as React from "react"
+import {
+  CaretSortIcon,
+  CheckIcon,
+  ChevronDownIcon,
+  ChevronUpIcon,
+} from "@radix-ui/react-icons"
+import * as SelectPrimitive from "@radix-ui/react-select"
+
+import { cn } from "@/lib/utils"
+
+const Select = SelectPrimitive.Root
+
+const SelectGroup = SelectPrimitive.Group
+
+const SelectValue = SelectPrimitive.Value
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <CaretSortIcon className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+))
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
+
+const SelectScrollUpButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className
+    )}
+    {...props}
+  >
+    <ChevronUpIcon />
+  </SelectPrimitive.ScrollUpButton>
+))
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName
+
+const SelectScrollDownButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className
+    )}
+    {...props}
+  >
+    <ChevronDownIcon />
+  </SelectPrimitive.ScrollDownButton>
+))
+SelectScrollDownButton.displayName =
+  SelectPrimitive.ScrollDownButton.displayName
+
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = "popper", ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        position === "popper" &&
+          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+        className
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectScrollUpButton />
+      <SelectPrimitive.Viewport
+        className={cn(
+          "p-1",
+          position === "popper" &&
+            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectScrollDownButton />
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+))
+SelectContent.displayName = SelectPrimitive.Content.displayName
+
+const SelectLabel = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn("px-2 py-1.5 text-sm font-semibold", className)}
+    {...props}
+  />
+))
+SelectLabel.displayName = SelectPrimitive.Label.displayName
+
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <CheckIcon className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+))
+SelectItem.displayName = SelectPrimitive.Item.displayName
+
+const SelectSeparator = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+))
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName
+
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+  SelectScrollUpButton,
+  SelectScrollDownButton,
+}


### PR DESCRIPTION

## Description
I added a selection to the example code section. I used the select component of Shadcn.

## Why is it needed?
We shouldn't exclusively target JavaScript developers with this tool. Therefore, I've added a selection in the example code section where you can choose your language.

## Screenshot or GIFs (if applicable)
![image](https://github.com/joschan21/profanity.dev/assets/102538661/e027afc0-df34-4509-824f-f3116bea2406)
![image](https://github.com/joschan21/profanity.dev/assets/102538661/19e01b14-52cf-4220-ae86-c4a6ff0a00e5)

