### PR TITLE
character normaliztion

### DIFF
--- a/vector-api/src/index.ts
+++ b/vector-api/src/index.ts
@@ -57,6 +57,7 @@ app.post('/', async (c) => {
     }
 
     message = message
+      .normalize("NFKC") // converts characters that look similar to english characters; ex. from https://lingojam.com/FancyTextGenerator
       .split(/\s/)
       .filter((word) => !WHITELIST.includes(word.toLowerCase()))
       .join(' ')


### PR DESCRIPTION
 Attempts to resolve issue #20

Uses string.prototype.normalize to convert ASCII characters to normal English characters. Fixes problems like bypassing with homohlyphs, 

Used NFKC to ensure that equivalent characters' sequences are represented uniquely and compatible.

Simple fix, no need for a library or a map of characters.

Resources used:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize