### PR TITLE
Fix: Typo mistake on .gitignore file

### DIFF
--- a/vector-api/.gitignore
+++ b/vector-api/.gitignore
@@ -2,4 +2,4 @@ dist
 node_modules
 .env
 wrangler.toml
-.wrwangler
+.wrangler


### PR DESCRIPTION
There is a typo on the declaration of the word '.wrangler'